### PR TITLE
BWSR-368: Baby Simple GraphQL Query Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # graphql-php-query-builder
-PHP Query Builder for GraphQL
-====
+[![Build Status](https://travis-ci.com/Hearst-Hatchery/graphql-php-query-builder.svg?branch=master)](https://travis-ci.com/Hearst-Hatchery/graphql-php-query-builder)
+[![codecov](https://codecov.io/gh/Hearst-Hatchery/graphql-php-query-builder/branch/master/graph/badge.svg)](https://codecov.io/gh/Hearst-Hatchery/graphql-php-query-builder)
 
 Simple QueryBuilder to deconstruct array and return GraphQL string can be used to request GraphQL server
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # graphql-php-query-builder
 PHP Query Builder for GraphQL
+====
+
+Simple QueryBuilder to deconstruct array and return GraphQL string can be used to request GraphQL server
+
+Build a QueryBuilder object:
+
+    $query = new QueryBuilder();
+
+Build query, set Requesting field, arguments and query type:
+
+    $query->setField('content');
+    $query->setArguments(['id' => '123']);
+    $query->setType('query');
+    $query->setObject([
+        'id',
+        'data',
+        'detail' => [
+            'name',
+            'model',
+            'year'
+            ]
+    ]);
+
+Render query and format the string:
+
+    $queryString= $query->buildQuery();
+
+Results in:
+
+    query{
+        content(id: "123") {
+            id
+            data
+            detail {
+                name
+                model
+                year
+            }
+        }
+    }

--- a/composer.lock
+++ b/composer.lock
@@ -1175,16 +1175,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.1.1",
+            "version": "6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "b097681a19a48e52706f57e47a09594bac4f7cab"
+                "reference": "0685fb6a43aed1b2e09804d1aaf17144c82861f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b097681a19a48e52706f57e47a09594bac4f7cab",
-                "reference": "b097681a19a48e52706f57e47a09594bac4f7cab",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/0685fb6a43aed1b2e09804d1aaf17144c82861f8",
+                "reference": "0685fb6a43aed1b2e09804d1aaf17144c82861f8",
                 "shasum": ""
             },
             "require": {
@@ -1234,7 +1234,11 @@
                 "testing",
                 "xunit"
             ],
+<<<<<<< HEAD
             "time": "2018-10-18T09:01:38+00:00"
+=======
+            "time": "2018-10-16T05:37:37+00:00"
+>>>>>>> 8ef811c... BWSR-368: Baby Simple graphql query builder
         },
         {
             "name": "phpunit/php-file-iterator",

--- a/composer.lock
+++ b/composer.lock
@@ -158,21 +158,21 @@
         },
         {
             "name": "codeception/phpunit-wrapper",
-            "version": "7.3.2",
+            "version": "7.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/phpunit-wrapper.git",
-                "reference": "a5633c736e0e0022bc5065b27c63f2d1aa97b69f"
+                "reference": "f18ed631f1eddbb603d72219f577d223b23a1f89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/phpunit-wrapper/zipball/a5633c736e0e0022bc5065b27c63f2d1aa97b69f",
-                "reference": "a5633c736e0e0022bc5065b27c63f2d1aa97b69f",
+                "url": "https://api.github.com/repos/Codeception/phpunit-wrapper/zipball/f18ed631f1eddbb603d72219f577d223b23a1f89",
+                "reference": "f18ed631f1eddbb603d72219f577d223b23a1f89",
                 "shasum": ""
             },
             "require": {
                 "phpunit/php-code-coverage": "^6.0",
-                "phpunit/phpunit": "~7.1.0|~7.2.0|~7.3.0",
+                "phpunit/phpunit": "^7.1",
                 "sebastian/comparator": "^3.0",
                 "sebastian/diff": "^3.0"
             },
@@ -197,7 +197,7 @@
                 }
             ],
             "description": "PHPUnit classes used by Codeception",
-            "time": "2018-10-07T21:30:01+00:00"
+            "time": "2018-06-20T20:07:21+00:00"
         },
         {
             "name": "codeception/stub",
@@ -1422,16 +1422,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.3.5",
+            "version": "7.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "7b331efabbb628c518c408fdfcaf571156775de2"
+                "reference": "c5a120ade60992bd671a912188ee9ee9f8083bbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7b331efabbb628c518c408fdfcaf571156775de2",
-                "reference": "7b331efabbb628c518c408fdfcaf571156775de2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c5a120ade60992bd671a912188ee9ee9f8083bbd",
+                "reference": "c5a120ade60992bd671a912188ee9ee9f8083bbd",
                 "shasum": ""
             },
             "require": {
@@ -1452,11 +1452,11 @@
                 "phpunit/php-timer": "^2.0",
                 "sebastian/comparator": "^3.0",
                 "sebastian/diff": "^3.0",
-                "sebastian/environment": "^3.1",
+                "sebastian/environment": "^3.1 || ^4.0",
                 "sebastian/exporter": "^3.1",
                 "sebastian/global-state": "^2.0",
                 "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
+                "sebastian/resource-operations": "^2.0",
                 "sebastian/version": "^2.0.1"
             },
             "conflict": {
@@ -1476,7 +1476,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.3-dev"
+                    "dev-master": "7.4-dev"
                 }
             },
             "autoload": {
@@ -1502,7 +1502,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-09-08T15:14:29+00:00"
+            "time": "2018-10-18T09:02:52+00:00"
         },
         {
             "name": "psr/http-message",
@@ -2081,25 +2081,25 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2119,7 +2119,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2018-10-04T04:07:39+00:00"
         },
         {
             "name": "sebastian/version",

--- a/composer.lock
+++ b/composer.lock
@@ -158,21 +158,21 @@
         },
         {
             "name": "codeception/phpunit-wrapper",
-            "version": "7.1.4",
+            "version": "7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/phpunit-wrapper.git",
-                "reference": "f18ed631f1eddbb603d72219f577d223b23a1f89"
+                "reference": "a5633c736e0e0022bc5065b27c63f2d1aa97b69f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/phpunit-wrapper/zipball/f18ed631f1eddbb603d72219f577d223b23a1f89",
-                "reference": "f18ed631f1eddbb603d72219f577d223b23a1f89",
+                "url": "https://api.github.com/repos/Codeception/phpunit-wrapper/zipball/a5633c736e0e0022bc5065b27c63f2d1aa97b69f",
+                "reference": "a5633c736e0e0022bc5065b27c63f2d1aa97b69f",
                 "shasum": ""
             },
             "require": {
                 "phpunit/php-code-coverage": "^6.0",
-                "phpunit/phpunit": "^7.1",
+                "phpunit/phpunit": "~7.1.0|~7.2.0|~7.3.0",
                 "sebastian/comparator": "^3.0",
                 "sebastian/diff": "^3.0"
             },
@@ -197,7 +197,7 @@
                 }
             ],
             "description": "PHPUnit classes used by Codeception",
-            "time": "2018-06-20T20:07:21+00:00"
+            "time": "2018-10-07T21:30:01+00:00"
         },
         {
             "name": "codeception/stub",
@@ -1170,16 +1170,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.1.1",
+            "version": "6.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "b097681a19a48e52706f57e47a09594bac4f7cab"
+                "reference": "4d3ae9b21a7d7e440bd0cf65565533117976859f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b097681a19a48e52706f57e47a09594bac4f7cab",
-                "reference": "b097681a19a48e52706f57e47a09594bac4f7cab",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4d3ae9b21a7d7e440bd0cf65565533117976859f",
+                "reference": "4d3ae9b21a7d7e440bd0cf65565533117976859f",
                 "shasum": ""
             },
             "require": {
@@ -1229,7 +1229,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-10-18T09:01:38+00:00"
+            "time": "2018-10-23T05:59:32+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1422,16 +1422,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.4.1",
+            "version": "7.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c5a120ade60992bd671a912188ee9ee9f8083bbd"
+                "reference": "7b331efabbb628c518c408fdfcaf571156775de2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c5a120ade60992bd671a912188ee9ee9f8083bbd",
-                "reference": "c5a120ade60992bd671a912188ee9ee9f8083bbd",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7b331efabbb628c518c408fdfcaf571156775de2",
+                "reference": "7b331efabbb628c518c408fdfcaf571156775de2",
                 "shasum": ""
             },
             "require": {
@@ -1452,11 +1452,11 @@
                 "phpunit/php-timer": "^2.0",
                 "sebastian/comparator": "^3.0",
                 "sebastian/diff": "^3.0",
-                "sebastian/environment": "^3.1 || ^4.0",
+                "sebastian/environment": "^3.1",
                 "sebastian/exporter": "^3.1",
                 "sebastian/global-state": "^2.0",
                 "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^2.0",
+                "sebastian/resource-operations": "^1.0",
                 "sebastian/version": "^2.0.1"
             },
             "conflict": {
@@ -1476,7 +1476,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.4-dev"
+                    "dev-master": "7.3-dev"
                 }
             },
             "autoload": {
@@ -1502,7 +1502,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-10-18T09:02:52+00:00"
+            "time": "2018-09-08T15:14:29+00:00"
         },
         {
             "name": "psr/http-message",
@@ -2081,25 +2081,25 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "2.0.1",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
-                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=5.6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -2119,7 +2119,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2018-10-04T04:07:39+00:00"
+            "time": "2015-07-28T20:34:47+00:00"
         },
         {
             "name": "sebastian/version",

--- a/composer.lock
+++ b/composer.lock
@@ -553,16 +553,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.13.0",
+            "version": "v2.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "7136aa4e0c5f912e8af82383775460d906168a10"
+                "reference": "54814c62d5beef3ba55297b9b3186ed8b8a1b161"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/7136aa4e0c5f912e8af82383775460d906168a10",
-                "reference": "7136aa4e0c5f912e8af82383775460d906168a10",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/54814c62d5beef3ba55297b9b3186ed8b8a1b161",
+                "reference": "54814c62d5beef3ba55297b9b3186ed8b8a1b161",
                 "shasum": ""
             },
             "require": {
@@ -573,7 +573,7 @@
                 "ext-tokenizer": "*",
                 "php": "^5.6 || >=7.0 <7.3",
                 "php-cs-fixer/diff": "^1.3",
-                "symfony/console": "^3.2 || ^4.0",
+                "symfony/console": "^3.4.17 || ^4.1.6",
                 "symfony/event-dispatcher": "^3.0 || ^4.0",
                 "symfony/filesystem": "^3.0 || ^4.0",
                 "symfony/finder": "^3.0 || ^4.0",
@@ -609,11 +609,6 @@
                 "php-cs-fixer"
             ],
             "type": "application",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.13-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "PhpCsFixer\\": "src/"
@@ -645,7 +640,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2018-08-23T13:15:44+00:00"
+            "time": "2018-10-21T00:32:10+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -1175,16 +1170,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.1.0",
+            "version": "6.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "0685fb6a43aed1b2e09804d1aaf17144c82861f8"
+                "reference": "b097681a19a48e52706f57e47a09594bac4f7cab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/0685fb6a43aed1b2e09804d1aaf17144c82861f8",
-                "reference": "0685fb6a43aed1b2e09804d1aaf17144c82861f8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b097681a19a48e52706f57e47a09594bac4f7cab",
+                "reference": "b097681a19a48e52706f57e47a09594bac4f7cab",
                 "shasum": ""
             },
             "require": {
@@ -1234,11 +1229,7 @@
                 "testing",
                 "xunit"
             ],
-<<<<<<< HEAD
             "time": "2018-10-18T09:01:38+00:00"
-=======
-            "time": "2018-10-16T05:37:37+00:00"
->>>>>>> 8ef811c... BWSR-368: Baby Simple graphql query builder
         },
         {
             "name": "phpunit/php-file-iterator",

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -47,10 +47,10 @@ class QueryBuilder
      */
     public function __construct($queryObject = [], $field = '', $arguments = [], $type = self::TYPE_QUERY)
     {
-        $this->object = $queryObject;
-        $this->field = $field;
-        $this->arguments = $arguments;
-        $this->type = $type;
+        $this->setObject($queryObject);
+        $this->setField($field);
+        $this->setArguments($arguments);
+        $this->setType($type);
     }
 
     /**
@@ -64,10 +64,10 @@ class QueryBuilder
             return '';
         }
 
-        $graphQLQuery = $this->type . "{\n" . $this->field;
+        $graphQLQuery = $this->type . "{\n\t" . $this->field;
         $graphQLQuery .= $this->arguments ? ' ' . $this->formatArguments($this->arguments) . "{\n" : "{\n";
-        $graphQLQuery .= $this->renderQueryObject($this->object);
-        $graphQLQuery .= "}\n";
+        $graphQLQuery .= $this->renderQueryObject($this->object, 2);
+        $graphQLQuery .= "\t}\n}\n";
 
         return $graphQLQuery;
     }
@@ -76,16 +76,21 @@ class QueryBuilder
      * renderQueryObject loop through given array and convert into graphql query format string
      * @return string rendered query string
      */
-    protected function renderQueryObject($queryObject = [])
+    protected function renderQueryObject($queryObject = [], $tabCount = 1)
     {
         $query = '';
+        $tab = "\t";
 
         foreach ($queryObject as $queryField => $queryFieldValue) {
             // recursive loop through every node
             if (is_array($queryFieldValue)) {
-                $query .= $queryField . " {\n" . $this->renderQueryObject($queryFieldValue) . "}\n";
+                $query .= str_repeat($tab, $tabCount) . $queryField . "{\n";
+                $tabCount++;
+                $query .= $this->renderQueryObject($queryFieldValue, $tabCount);
+                $tabCount--;
+                $query .= str_repeat($tab, $tabCount) . "}\n" ;
             } else {
-                $query .= $queryFieldValue . "\n\n";
+                $query .= str_repeat($tab, $tabCount) . $queryFieldValue . "\n";
             }
         }
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -76,7 +76,7 @@ class QueryBuilder
      * renderQueryObject loop through given array and convert into graphql query format string
      * @return string rendered query string
      */
-    protected function renderQueryObject($queryObject = [], $tabCount = 1)
+    protected function renderQueryObject($queryObject = [], $tabCount = 0)
     {
         $query = '';
         $tab = "\t";

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -13,13 +13,13 @@ class QueryBuilder
      * PHP array that need to be converted and built as graphQL server supported query
      * @var array
      */
-    protected $object;
+    protected $queryObject;
 
     /**
      * String of graphQL fields that can refer to Objects
      * @var string
      */
-    protected $field;
+    protected $fields;
 
     /**
      * Set of arguments for fetching data eg. content(ID: '1234')
@@ -40,70 +40,74 @@ class QueryBuilder
     /**
      * QueryBuilder constructor
      *
-     * @param array $queryObject
-     * @param string $field
+     * @param array $query
+     * @param string $fields
      * @param array $arguments
      * @param string $type
      */
-    public function __construct($queryObject = [], $field = '', $arguments = [], $type = self::TYPE_QUERY)
+    public function __construct($query = [], $fields = '', $arguments = [], $type = self::TYPE_QUERY)
     {
-        $this->setObject($queryObject);
-        $this->setField($field);
+        $this->setQueryObject($query);
+        $this->setField($fields);
         $this->setArguments($arguments);
         $this->setType($type);
     }
 
     /**
      * buildQuery format query type, field, arguments and rendered query string to build full query
-     * that can be used for requesting graphql server
+     * that can be used for requesting graphQL server
      * @return string GraphQl query string
      */
     public function buildQuery()
     {
-        if (empty($this->object)) {
+        if (empty($this->queryObject)) {
             return '';
         }
 
-        $graphQLQuery = $this->type . "{\n\t" . $this->field;
+        $graphQLQuery = "{\n\t" . $this->fields;
         $graphQLQuery .= $this->arguments ? ' ' . $this->formatArguments($this->arguments) . "{\n" : "{\n";
-        $graphQLQuery .= $this->renderQueryObject($this->object, 2);
+        $graphQLQuery .= $this->renderQueryObject($this->queryObject, 2);
         $graphQLQuery .= "\t}\n}";
 
         return $graphQLQuery;
     }
 
     /**
-     * renderQueryObject loop through given array and convert into graphql query format string
+     * renderQueryObject loop through given query array and convert into graphQL query format string
+     *
+     * @param array $query
+     * @param int $tabCount
      * @return string rendered query string
      */
-    protected function renderQueryObject($queryObject = [], $tabCount = 0)
+    protected function renderQueryObject($query = [], $tabCount = 0)
     {
-        $query = '';
+        $queryString = '';
         $tab = "\t";
 
-        foreach ($queryObject as $queryField => $queryFieldValue) {
+        foreach ($query as $queryField => $queryFieldValue) {
             // recursive loop through every node
             if (!is_numeric($queryField)) {
-                $query .= str_repeat($tab, $tabCount) . $queryField . "{\n";
+                $queryString .= str_repeat($tab, $tabCount) . $queryField . "{\n";
                 $tabCount++;
 
                 if (is_array($queryFieldValue)) {
-                    $query .= $this->renderQueryObject($queryFieldValue, $tabCount);
+                    $queryString .= $this->renderQueryObject($queryFieldValue, $tabCount);
                 } else {
-                    $query .= str_repeat($tab, $tabCount) . $queryFieldValue . "\n";
+                    $queryString .= str_repeat($tab, $tabCount) . $queryFieldValue . "\n";
                 }
                 $tabCount--;
-                $query .= str_repeat($tab, $tabCount) . "}\n" ;
+                $queryString .= str_repeat($tab, $tabCount) . "}\n" ;
             } else {
-                $query .= str_repeat($tab, $tabCount) . $queryFieldValue . "\n";
+                $queryString .= str_repeat($tab, $tabCount) . $queryFieldValue . "\n";
             }
         }
 
-        return $query;
+        return $queryString;
     }
 
     /**
      * formatArguments loop through arguments array and format it to be ready to concatenate with query string
+     * @param array $arguments
      * @return string formatted arguments string
      */
     protected function formatArguments($arguments)
@@ -124,22 +128,22 @@ class QueryBuilder
     }
 
     /**
-     * @param array $object
+     * @param array $queryObject
      * @return QueryBuilder
      */
-    public function setObject($object)
+    public function setQueryObject($queryObject)
     {
-        $this->object = $object ?? [];
+        $this->queryObject = $queryObject ?? [];
         return $this;
     }
 
     /**
-     * @param string $field
+     * @param string $fields
      * @return QueryBuilder
      */
-    public function setField($field)
+    public function setField($fields)
     {
-        $this->field = $field ?? '';
+        $this->fields = $fields ?? '';
         return $this;
     }
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -38,7 +38,7 @@ class QueryBuilder
     const TYPE_MUTATION = 'mutation';
 
     /**
-     * QueryBuilder constructor.
+     * QueryBuilder constructor
      *
      * @param array $queryObject
      * @param string $field
@@ -53,13 +53,18 @@ class QueryBuilder
         $this->type = $type;
     }
 
-    protected function buildQuery()
+    /**
+     * buildQuery format query type, field, arguments and rendered query string to build full query
+     * that can be used for requesting graphql server
+     * @return string GraphQl query string
+     */
+    public function buildQuery()
     {
         if (empty($this->object)) {
             return '';
         }
 
-        $graphQLQuery = $this->type . "{\n" . $this->field; //content
+        $graphQLQuery = $this->type . "{\n" . $this->field;
         $graphQLQuery .= $this->arguments ? ' ' . $this->formatArguments($this->arguments) . "{\n" : "{\n";
         $graphQLQuery .= $this->renderQueryObject($this->object);
         $graphQLQuery .= "}\n";
@@ -67,29 +72,39 @@ class QueryBuilder
         return $graphQLQuery;
     }
 
+    /**
+     * renderQueryObject loop through given array and convert into graphql query format string
+     * @return string rendered query string
+     */
     protected function renderQueryObject($queryObject = [])
     {
         $query = '';
 
-        foreach ($queryObject as $queryField) {
+        foreach ($queryObject as $queryField => $queryFieldValue) {
             // recursive loop through every node
-            if (is_array($queryField)) {
-                $query .= $this->renderQueryObject($queryField);
+            if (is_array($queryFieldValue)) {
+                $query .= $queryField . " {\n" . $this->renderQueryObject($queryFieldValue) . "}\n";
             } else {
-                $query .= $queryField . "\n";
+                $query .= $queryFieldValue . "\n\n";
             }
         }
 
         return $query;
     }
 
+    /**
+     * formatArguments loop through arguments array and format it to be ready to concatenate with query string
+     * @return string formatted arguments string
+     */
     protected function formatArguments($arguments)
     {
         if ($arguments) {
             $formattedArgument = [];
             foreach ($arguments as $name => $type) {
                 if (is_array($type)) {
-                    $type = '[' . implode(',', $type) . ']';
+                    $type = '["' . implode('","', $type) . '"]';
+                } else {
+                    $type = '"' . $type . '"';
                 }
                 $formattedArgument[] = $name . ': ' . $type;
             }
@@ -99,12 +114,42 @@ class QueryBuilder
     }
 
     /**
+     * @param array $object
+     * @return QueryBuilder
+     */
+    public function setObject($object)
+    {
+        $this->object = $object ?? [];
+        return $this;
+    }
+
+    /**
+     * @param string $field
+     * @return QueryBuilder
+     */
+    public function setField($field)
+    {
+        $this->field = $field ?? '';
+        return $this;
+    }
+
+    /**
      * @param array $arguments
      * @return QueryBuilder
      */
     public function setArguments($arguments)
     {
-        $this->arguments = $arguments;
+        $this->arguments = $arguments ?? [];
+        return $this;
+    }
+
+    /**
+     * @param string $type
+     * @return QueryBuilder
+     */
+    public function setType($type)
+    {
+        $this->type = $type ?? '';
         return $this;
     }
 }

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -48,7 +48,7 @@ class QueryBuilder
     public function __construct($query = [], $fields = '', $arguments = [], $type = self::TYPE_QUERY)
     {
         $this->setQueryObject($query);
-        $this->setField($fields);
+        $this->setFields($fields);
         $this->setArguments($arguments);
         $this->setType($type);
     }
@@ -141,7 +141,7 @@ class QueryBuilder
      * @param string $fields
      * @return QueryBuilder
      */
-    public function setField($fields)
+    public function setFields($fields)
     {
         $this->fields = $fields ?? '';
         return $this;

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -67,7 +67,7 @@ class QueryBuilder
         $graphQLQuery = $this->type . "{\n\t" . $this->field;
         $graphQLQuery .= $this->arguments ? ' ' . $this->formatArguments($this->arguments) . "{\n" : "{\n";
         $graphQLQuery .= $this->renderQueryObject($this->object, 2);
-        $graphQLQuery .= "\t}\n}\n";
+        $graphQLQuery .= "\t}\n}";
 
         return $graphQLQuery;
     }
@@ -83,10 +83,15 @@ class QueryBuilder
 
         foreach ($queryObject as $queryField => $queryFieldValue) {
             // recursive loop through every node
-            if (is_array($queryFieldValue)) {
+            if (!is_numeric($queryField)) {
                 $query .= str_repeat($tab, $tabCount) . $queryField . "{\n";
                 $tabCount++;
-                $query .= $this->renderQueryObject($queryFieldValue, $tabCount);
+
+                if (is_array($queryFieldValue)) {
+                    $query .= $this->renderQueryObject($queryFieldValue, $tabCount);
+                } else {
+                    $query .= str_repeat($tab, $tabCount) . $queryFieldValue . "\n";
+                }
                 $tabCount--;
                 $query .= str_repeat($tab, $tabCount) . "}\n" ;
             } else {

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -10,13 +10,101 @@ namespace GraphQLQueryBuilder;
 class QueryBuilder
 {
     /**
+     * PHP array that need to be converted and built as graphQL server supported query
+     * @var array
+     */
+    protected $object;
+
+    /**
      * String of graphQL fields that can refer to Objects
      * @var string
      */
-    public $field;
+    protected $field;
 
-    public function __construct($field = '')
+    /**
+     * Set of arguments for fetching data eg. content(ID: '1234')
+     * @var array
+     */
+    protected $arguments;
+
+    /**
+     * String of graphQL request type that can
+     * @var string
+     */
+    protected $type;
+
+    // TODO: Add Fragments & Variables for full query and mutation
+    const TYPE_QUERY = 'query';
+    const TYPE_MUTATION = 'mutation';
+
+    /**
+     * QueryBuilder constructor.
+     *
+     * @param array $queryObject
+     * @param string $field
+     * @param array $arguments
+     * @param string $type
+     */
+    public function __construct($queryObject = [], $field = '', $arguments = [], $type = self::TYPE_QUERY)
     {
+        $this->object = $queryObject;
         $this->field = $field;
+        $this->arguments = $arguments;
+        $this->type = $type;
+    }
+
+    protected function buildQuery()
+    {
+        if (empty($this->object)) {
+            return '';
+        }
+
+        $graphQLQuery = $this->type . "{\n" . $this->field; //content
+        $graphQLQuery .= $this->arguments ? ' ' . $this->formatArguments($this->arguments) . "{\n" : "{\n";
+        $graphQLQuery .= $this->renderQueryObject($this->object);
+        $graphQLQuery .= "}\n";
+
+        return $graphQLQuery;
+    }
+
+    protected function renderQueryObject($queryObject = [])
+    {
+        $query = '';
+
+        foreach ($queryObject as $queryField) {
+            // recursive loop through every node
+            if (is_array($queryField)) {
+                $query .= $this->renderQueryObject($queryField);
+            } else {
+                $query .= $queryField . "\n";
+            }
+        }
+
+        return $query;
+    }
+
+    protected function formatArguments($arguments)
+    {
+        if ($arguments) {
+            $formattedArgument = [];
+            foreach ($arguments as $name => $type) {
+                if (is_array($type)) {
+                    $type = '[' . implode(',', $type) . ']';
+                }
+                $formattedArgument[] = $name . ': ' . $type;
+            }
+            return '(' . implode(', ', $formattedArgument) . ') ';
+        }
+        return '';
+    }
+
+    /**
+     * @param array $arguments
+     * @return QueryBuilder
+     */
+    public function setArguments($arguments)
+    {
+        $this->arguments = $arguments;
+        return $this;
     }
 }

--- a/test/codeception/unit/src/QueryBuilderTest.php
+++ b/test/codeception/unit/src/QueryBuilderTest.php
@@ -10,8 +10,6 @@ use Codeception\Util\ReflectionHelper;
  */
 class QueryBuilderTest extends \Codeception\Test\Unit
 {
-    // An instance of the behavior to be tested
-    private $queryBuilder;
     /**
      * @var \UnitTester
      */
@@ -37,7 +35,7 @@ class QueryBuilderTest extends \Codeception\Test\Unit
     public function testConstructor()
     {
         $queryBuilder = Stub::make('GraphQLQueryBuilder\QueryBuilder', [
-            'setObject' => function () {
+            'setQueryObject' => function () {
                 // Verify this method was called
                 verify(true)->true();
             },
@@ -68,14 +66,14 @@ class QueryBuilderTest extends \Codeception\Test\Unit
         $arguments = ['id' => 123];
         $object = ['id' => 123, 'type', 'data' => ['size', 'date']];
 
-        $this->querybuilder->setObject($object);
+        $this->querybuilder->setQueryObject($object);
         $this->querybuilder->setArguments($arguments);
         $this->querybuilder->setField('image');
         $this->querybuilder->setType('query');
 
         $output = $this->querybuilder->buildQuery();
         $expected = <<<Query
-query{
+{
 	image (id: "123") {
 		id{
 			123
@@ -100,7 +98,7 @@ Query;
     {
         $object = '';
 
-        $this->querybuilder->setObject($object);
+        $this->querybuilder->setQueryObject($object);
 
         $output = $this->querybuilder->buildQuery();
 
@@ -188,12 +186,12 @@ Query;
     /**
      * testSetObject tests that setObject set array object to current QueryBuilder
      *
-     * @covers ::setObject()
+     * @covers ::setQueryObject()
      */
     public function testSetObject()
     {
         $object = ['id' => 123, 'data'];
-        $output = $this->querybuilder->setObject($object);
+        $output = $this->querybuilder->setQueryObject($object);
         verify($output)->equals($this->querybuilder);
     }
 

--- a/test/codeception/unit/src/QueryBuilderTest.php
+++ b/test/codeception/unit/src/QueryBuilderTest.php
@@ -39,7 +39,7 @@ class QueryBuilderTest extends \Codeception\Test\Unit
                 // Verify this method was called
                 verify(true)->true();
             },
-            'setField' => function () {
+            'setFields' => function () {
                 // Verify this method was called
                 verify(true)->true();
             },
@@ -68,7 +68,7 @@ class QueryBuilderTest extends \Codeception\Test\Unit
 
         $this->querybuilder->setQueryObject($object);
         $this->querybuilder->setArguments($arguments);
-        $this->querybuilder->setField('image');
+        $this->querybuilder->setFields('image');
         $this->querybuilder->setType('query');
 
         $output = $this->querybuilder->buildQuery();
@@ -196,14 +196,14 @@ Query;
     }
 
     /**
-     * testSetField tests that setField set field string to current QueryBuilder
+     * testSetField tests that setFields set field string to current QueryBuilder
      *
-     * @covers ::setField()
+     * @covers ::setFields()
      */
-    public function testSetField()
+    public function testSetFields()
     {
         $field = 'foo';
-        $output = $this->querybuilder->setField($field);
+        $output = $this->querybuilder->setFields($field);
         verify($output)->equals($this->querybuilder);
     }
 

--- a/test/codeception/unit/src/QueryBuilderTest.php
+++ b/test/codeception/unit/src/QueryBuilderTest.php
@@ -2,6 +2,7 @@
 namespace GraphQLQueryBuilder\Tests;
 
 use GraphQLQueryBuilder\QueryBuilder;
+use \Codeception\Util\Stub;
 
 /**
  *  @coversDefaultClass GraphQLQueryBuilder\QueryBuilder
@@ -27,6 +28,25 @@ class QueryBuilderTest extends \Codeception\Test\Unit
      */
     public function testConstructor()
     {
-        verify($this->queryBuilder->field)->equals('');
+        $queryBuilder = Stub::make('GraphQLQueryBuilder\QueryBuilder', [
+            'setObject' => function () {
+                // Verify this method was called
+                verify(true)->true();
+            },
+            'setField' => function () {
+                // Verify this method was called
+                verify(true)->true();
+            },
+            'setArguments' => function () {
+                // Verify this method was called
+                verify(true)->true();
+            },
+            'setType' => function () {
+                // Verify this method was called
+                verify(true)->true();
+            },
+        ]);
+
+        $queryBuilder->__construct();
     }
 }

--- a/test/codeception/unit/src/QueryBuilderTest.php
+++ b/test/codeception/unit/src/QueryBuilderTest.php
@@ -9,15 +9,22 @@ use \Codeception\Util\Stub;
  */
 class QueryBuilderTest extends \Codeception\Test\Unit
 {
+    // An instance of the behavior to be tested
+    private $queryBuilder;
+    /**
+     * @var \UnitTester
+     */
+    protected $tester;
+
     protected function _before()
     {
-        $this->queryBuilder = new QueryBuilder();
+        $this->querybuilder = Stub::make('GraphQLQueryBuilder\QueryBuilder');
     }
 
     protected function _after()
     {
         // unset the blank class after each test
-        unset($this->queryBuilder);
+        unset($this->querybuilder);
     }
 
     /**
@@ -48,5 +55,53 @@ class QueryBuilderTest extends \Codeception\Test\Unit
         ]);
 
         $queryBuilder->__construct();
+    }
+
+    /**
+     * testSetObject tests that setObject set array object to current QueryBuilder
+     *
+     * @covers ::setObject()
+     */
+    public function testSetObject()
+    {
+        $object = ['id' => 123, 'data'];
+        $output = $this->querybuilder->setObject($object);
+        verify($output)->equals($this->querybuilder);
+    }
+
+    /**
+     * testSetField tests that setField set field string to current QueryBuilder
+     *
+     * @covers ::setField()
+     */
+    public function testSetField()
+    {
+        $field = 'foo';
+        $output = $this->querybuilder->setField($field);
+        verify($output)->equals($this->querybuilder);
+    }
+
+    /**
+     * testSetArguments tests that setArguments set arguments to current QueryBuilder
+     *
+     * @covers ::setArguments()
+     */
+    public function testSetArguments()
+    {
+        $arguments = ['id' => 123];
+        $output = $this->querybuilder->setArguments($arguments);
+        verify($output)->equals($this->querybuilder);
+    }
+
+    /**
+     * testSetType tests that setType set type string to current QueryBuilder
+     *
+     * @covers ::setType()
+     */
+    public function testSetType()
+    {
+        $type = 'query';
+        $output = $this->querybuilder->setType($type);
+        verify($output)->equals($this->querybuilder);
     }
 }


### PR DESCRIPTION
- [ ] - Functionality to convert a PHP array into a GraphQL query 

Testing data set. 
new QueryBuilder object
```
new QueryBuilder= [
    ['id', 'data', 'vehicle' => ['name', 'model', 'year']],  // object
    'content',  // field
    ['ID' => '1234'], // arguments
    'query' // type
]; 
```
array of `$object` to be deconstructed
```
$array = [
      'id', 
      'data', =>[
           'vehicle' => [
                 'name', 
                 'model', 
                 'year'
            ]
      ]
];
```
Expected query 
```
query {
content(ID: "1234") {
    id
    data {
       vehicle {
          name
          model
          year
      }
    }
  }
}
```

