### PR TITLE
Ted 872 process string array

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -158,7 +158,6 @@ class QueryBuilder
                     } else {
                         $type = '[' . implode(',', $type) . ']' ;
                     }
-                    // $type = gettype($type) === 'string' ? '["' . implode('","', $type) . '"]' : '[' . implode(',', $type) . ']' ;
                 } else {
                     $type = gettype($type) === 'string' ? '"' . $type . '"' : $type ;
                 }

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -153,7 +153,12 @@ class QueryBuilder
             $formattedArgument = [];
             foreach ($arguments as $name => $type) {
                 if (is_array($type)) {
-                    $type = gettype($type) === 'string' ? '["' . implode('","', $type) . '"]' : '[' . implode(',', $type) . ']' ;
+                    if (count($type) > 0 && is_string($type[0])) {
+                        $type = '["' . implode('","', $type) . '"]';
+                    } else {
+                        $type = '[' . implode(',', $type) . ']' ;
+                    }
+                    // $type = gettype($type) === 'string' ? '["' . implode('","', $type) . '"]' : '[' . implode(',', $type) . ']' ;
                 } else {
                     $type = gettype($type) === 'string' ? '"' . $type . '"' : $type ;
                 }

--- a/test/codeception/unit/src/QueryBuilderTest.php
+++ b/test/codeception/unit/src/QueryBuilderTest.php
@@ -147,6 +147,16 @@ Query;
                 ],
                 'expected' => '(ids: [123,456], type: "image") ',
             ],
+            'multi arguments string array passed in' => [
+                'arguments' => [
+                    'ids' => [
+                        '123',
+                        '456',
+                    ],
+                    'type' => 'image',
+                ],
+                'expected' => '(ids: ["123","456"], type: "image") ',
+            ],
         ];
     }
 


### PR DESCRIPTION
**JIRA URL**
https://thetower.atlassian.net/browse/TED-872

**Description**
For TED-872 I'm passing an array of string content ID's to Voltron in CC. Currently `QueryBuilder.php` checks `if (is_array($type))` which obviously evaluates to `true` when array is passed in. But on the line below it checks `gettype($type) === 'string'` which will always be `false` because the type is an array; therefore the array will never get formatted as a string. 

Since ID's are strings in Voltron I need the `implode` portion of the code to be reachable, hence this change.